### PR TITLE
Add Saraswat memory safety paper to references

### DIFF
--- a/common/browser.bib
+++ b/common/browser.bib
@@ -206,3 +206,13 @@ WEBKIT,
   publisher = {ACM},
   address = {New York, NY, USA},
 }
+
+@techreport{
+  memory-safety,
+  author       = {Saraswat, Vijay},
+  institution  = {AT&T Research},
+  month        = {August},
+  title        = {Java is not type-safe},
+  url          = {http://www.cis.upenn.edu/~bcpierce/courses/629/papers/Saraswat-javabug.html},
+  year         = {1997},
+}


### PR DESCRIPTION
I'm pretty bad at LaTeX so no idea if this is the best way of citing this.
