### PR TITLE
Array accesses are not statically checked

### DIFF
--- a/icse16-servo/intro.tex
+++ b/icse16-servo/intro.tex
@@ -44,8 +44,8 @@ than in current browsers.
 
 To address memory-related safety issues, we are using a new systems programming language,
 Rust~\cite{RUST}.
-In Rust, errors such as off-by-one array access or memory buffer use after free are
-prevented statically at compile time.
+In Rust, errors such as memory buffer use after free and data races are prevented statically at
+compile time.
 
 For parallelism and power, we scale across a wide variety of hardware by building either data-
 or task-parallelism, as appropriate, into each part of the web platform.


### PR DESCRIPTION
They are dynamically checked. Though technically the fact that the API is designed so that you can't do unchecked access without unsafe is a form of static check, I guess.

r? @larsbergstrom
